### PR TITLE
Fixed typo.

### DIFF
--- a/pythonx/cm_sources/cm_otherbuf.py
+++ b/pythonx/cm_sources/cm_otherbuf.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 class Source(Base):
 
     class BufferData:
-        __sltos__ = ('changed', 'changedtick', 'deleted', 'words')
+        __slots__ = ('changed', 'changedtick', 'deleted', 'words')
 
         def __init__(self):
             self.changed = False


### PR DESCRIPTION
There was a typo in the `__slots__` variable declaration, making it useless.